### PR TITLE
Implement YADS concat

### DIFF
--- a/src/marray.spec.ts
+++ b/src/marray.spec.ts
@@ -28,6 +28,32 @@ describe('array', () => {
     a[2] = 4;
     expect(a.reduceTo(2, Total)).toEqual(19);
   });
+
+  describe('MArray.concat test suite', () => {
+    it('should not mutate original array when concating', () => {
+      const a = new MArray(1, 2, 3);
+
+      a.concat(4);
+
+      expect(a.toArray()).toEqual([1, 2, 3]);
+    });
+
+    it('should return same array when concat with no arguments ', () => {
+      const a = new MArray(1, 2, 3);
+
+      const result = a.concat();
+
+      expect(result.toArray()).toEqual([1, 2, 3]);
+    });
+
+    it('should concat with arguments of multiple types', () => {
+      const a = new MArray(1, 2, 3);
+
+      const result = a.concat(4, [5, 6], new MArray(7, 8));
+
+      expect(result.toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+  });
 });
 
 type Node = { type: 'h1' | 'h2' | 'h3' | 'p'; text: string };

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -84,6 +84,26 @@ export class MArray<T> {
   }
 
   /**
+   * Combines two or more arrays.
+   * @param items Additional items to add to the end of array.
+   */
+  concat(...items: (T | ConcatArray<T> | MArray<T>)[]): MArray<T> {
+    const resultArray = this.toArray();
+
+    for (const item of items) {
+      if (Array.isArray(item)) {
+        resultArray.push(...item);
+      } else if (item instanceof MArray) {
+        resultArray.push(...item);
+      } else {
+        resultArray.push(item as T);
+      }
+    }
+
+    return MArray.from(resultArray);
+  }
+
+  /**
    * Get element at the given index
    * @param index the index to search for
    */

--- a/src/tree-utils.ts
+++ b/src/tree-utils.ts
@@ -267,6 +267,9 @@ export function* iterate<T>(
   index: number = 0,
   count: number = root.getField(Size),
 ) {
+  if (root.getField(Size) === 0) {
+    return;
+  }
   if (index < 0) {
     index = root.getField(Size) + index;
   }

--- a/tests/structure.test.ts
+++ b/tests/structure.test.ts
@@ -16,8 +16,8 @@ describe('Internal tree structure', () => {
   });
 
   it('Creates a tree', () => {
-    const data: number[] = [0];
-    for (let i = 1; i < 11; ++i) {
+    const data: number[] = [];
+    for (let i = 0; i < 11; ++i) {
       const tree = fromArray(data);
       expect(isBalanced(tree)).toBeTruthy();
       expect(tree.getField(Size)).toEqual(i);


### PR DESCRIPTION
This PR implements `concat` method for `MArray`. The behavior and signature can be expected to be same as `Array.concat`.