### PR TITLE
EDI-1621 Implement MArray.slice()

### DIFF
--- a/src/marray.spec.ts
+++ b/src/marray.spec.ts
@@ -108,7 +108,7 @@ describe('array', () => {
       let res = a.every(x => x.includes('x'));
 
       expect(res).toBe(true);
-    })
+    });
 
     it('every() returns false if at least one element does not satisfy a predicate', () => {
       let a = new MArray('xy', 'xz', 'rxb', 'gxb', 'b');
@@ -116,7 +116,7 @@ describe('array', () => {
       let res = a.every(x => x.includes('x'));
 
       expect(res).toBe(false);
-    })
+    });
 
     it('every() returns false if all the elements do not satisfy a predicate', () => {
       let a = new MArray('xy', 'xz', 'rxb', 'gxb', 'b');
@@ -124,7 +124,7 @@ describe('array', () => {
       let res = a.every(x => x.includes('l'));
 
       expect(res).toBe(false);
-    })
+    });
 
     it('some() returns true if at least one element satisfies a predicate', () => {
       let a = new MArray('xy', 'xz', 'rxb', 'gxb', 'bx');
@@ -132,7 +132,7 @@ describe('array', () => {
       let res = a.some(x => x.includes('y'));
 
       expect(res).toBe(true);
-    })
+    });
 
     it('some() returns true if all the elements satisfy a predicate', () => {
       let a = new MArray('xy', 'xz', 'rxb', 'gxb', 'bx');
@@ -140,7 +140,7 @@ describe('array', () => {
       let res = a.some(x => x.includes('x'));
 
       expect(res).toBe(true);
-    })
+    });
 
     it('some() returns false if none of the elements satisfy a predicate', () => {
       let a = new MArray('xy', 'xz', 'rxb', 'gxb', 'bx');
@@ -148,7 +148,7 @@ describe('array', () => {
       let res = a.some(x => x.includes('l'));
 
       expect(res).toBe(false);
-    })
+    });
   });
 
   describe('MArray - mapping, filtering and reducing', () => {
@@ -202,6 +202,39 @@ describe('array', () => {
       let result = arr.filter(filter, { f: (x: number) => x % 2 === 0 });
 
       expect(result).toEqual(res);
+    });
+  });
+
+  describe('MArray slice method tests suite', () => {
+    it('should return a copy of the array when passed no arguments', () => {
+      const arr = new MArray(1, 3, 5, 7, 9);
+
+      expect(arr.slice()).toEqual(arr);
+      expect(arr.length).toEqual(5);
+    });
+
+    it('should not modify the original array', () => {
+      const arr = new MArray(0, 1, 1, 2, 3, 5);
+      arr.slice(1, 3);
+
+      expect(arr.length).toEqual(6);
+    });
+
+    it('should behave in the same way as Array.slice', () => {
+      const arr = [1, 2, 3, 4, 5];
+      const marr = MArray.from(arr);
+
+      expect(marr.slice().toArray()).toEqual(arr.slice());
+      expect(marr.slice(4).toArray()).toEqual(arr.slice(4));
+      expect(marr.slice(6).toArray()).toEqual(arr.slice(6));
+      expect(marr.slice(0, 3).toArray()).toEqual(arr.slice(0, 3));
+      expect(marr.slice(1, 3).toArray()).toEqual(arr.slice(1, 3));
+      expect(marr.slice(4, 3).toArray()).toEqual(arr.slice(4, 3));
+      expect(marr.slice(1, 6).toArray()).toEqual(arr.slice(1, 6));
+      expect(marr.slice(-2).toArray()).toEqual(arr.slice(-2));
+      expect(marr.slice(1, -1).toArray()).toEqual(arr.slice(1, -1));
+      expect(marr.slice(-2, -3).toArray()).toEqual(arr.slice(-2, -3));
+      expect(marr.slice(-3, -2).toArray()).toEqual(arr.slice(-3, -2));
     });
   });
 

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -81,9 +81,12 @@ export class MArray<T> {
     }
     end = !end || end > this.length ? this.length : end;
 
-    for (let i = start; i < end; i++) {
-      extractedElements.push(this[i]);
+    if (end > start) {
+      for (let node of tu.iterateData(this.$data, start, end - start)) {
+        extractedElements.push(node);
+      }
     }
+
     return extractedElements;
   }
 

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -62,6 +62,32 @@ export class MArray<T> {
   }
 
   /**
+   * Like Array.slice - Returns a section of an array.
+   * @param start The beginning of the specified portion of the array.
+   * @param end The end of the specified portion of the array, exclusive of the element at the index 'end'.
+   */
+  slice(start?: number, end?: number) {
+    const extractedElements = new MArray<T>();
+
+    if (start > this.length) {
+      return extractedElements;
+    } else if (start < 0) {
+      start = this.length + start;
+    }
+    start = start ?? 0;
+
+    if (end < 0) {
+      end = this.length + end;
+    }
+    end = !end || end > this.length ? this.length : end;
+
+    for (let i = start; i < end; i++) {
+      extractedElements.push(this[i]);
+    }
+    return extractedElements;
+  }
+
+  /**
    * Like Array.splice
    * @param at the position
    * @param deleteCount item count to delete
@@ -109,12 +135,14 @@ export class MArray<T> {
    * @param thisArg?
    * @returns boolean
    */
-  every(predicate: (value: T, index?: number, mArray?: MArray<T>) => unknown, thisArg?: any): boolean{
+  every(
+    predicate: (value: T, index?: number, mArray?: MArray<T>) => unknown,
+    thisArg?: any,
+  ): boolean {
     let index = 0;
 
-    for(let item of this){
-      if (!predicate.call(thisArg, item, index, this))
-        return false;
+    for (let item of this) {
+      if (!predicate.call(thisArg, item, index, this)) return false;
 
       index++;
     }
@@ -122,18 +150,20 @@ export class MArray<T> {
     return true;
   }
 
-    /**
+  /**
    * Like Array.some; returns true if at least one element satisfies the predicate
    * @param predicate
    * @param thisArg?
    * @returns boolean
    */
-  some(predicate: (value: T, index?: number, mArray?: MArray<T>) => unknown, thisArg?: any): boolean{
+  some(
+    predicate: (value: T, index?: number, mArray?: MArray<T>) => unknown,
+    thisArg?: any,
+  ): boolean {
     let index = 0;
 
-    for(let item of this){
-      if (predicate.call(thisArg, item, index, this))
-        return true;
+    for (let item of this) {
+      if (predicate.call(thisArg, item, index, this)) return true;
 
       index++;
     }


### PR DESCRIPTION
Implements a `MArray.slice()` method, that should behave same as Array.slice (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).

Task: [EDI-1621](https://h4jira.atlassian.net/browse/EDI-1621)