### PR TITLE
EDI-1619 Modify MArray.splice 

### DIFF
--- a/src/marray.spec.ts
+++ b/src/marray.spec.ts
@@ -238,6 +238,111 @@ describe('array', () => {
     });
   });
 
+  describe('MArray splice method tests suite', () => {
+    let arr = new Array();
+    let marr = new MArray();
+
+    beforeEach(() => {
+      arr = [1, 2, 3, 4, 5];
+      marr = MArray.from(arr);
+    });
+
+    it('should return a copy of the array and remove all elements from the original one', () => {
+      const spliced = marr.splice(0);
+
+      expect(marr.length).toEqual(0);
+      expect(spliced.toArray()).toEqual(arr.splice(0));
+    });
+
+    it('should preserve all elements from the original array', () => {
+      const originalLength = marr.length;
+      const spliced = marr.splice(1, 0);
+
+      expect(marr.length).toEqual(originalLength);
+      expect(spliced.length).toEqual(0);
+      expect(spliced.toArray()).toEqual(arr.splice(1, 0));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove the last element of the array and return it', () => {
+      const spliced = marr.splice(marr.length - 1);
+
+      expect(marr.length).toEqual(4);
+      expect(spliced.toArray()).toEqual(arr.splice(arr.length - 1));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove the two last elements (negative index) and return them', () => {
+      const spliced = marr.splice(-2);
+
+      expect(spliced.toArray()).toEqual([4, 5]);
+      expect(spliced.toArray()).toEqual(arr.splice(-2));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should return an empty array for a non-existing index', () => {
+      const spliced = marr.splice(6);
+
+      expect(spliced.length).toEqual(0);
+      expect(spliced.toArray()).toEqual(arr.splice(6));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove the first two elements and return them', () => {
+      const spliced = marr.splice(0, 2);
+
+      expect(spliced.length).toEqual(2);
+      expect(spliced.toArray()).toEqual(arr.splice(0, 2));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove the next two elements from the specified index and return them', () => {
+      const spliced = marr.splice(1, 2);
+
+      expect(spliced.toArray()).toEqual([2, 3]);
+      expect(spliced.toArray()).toEqual(arr.splice(1, 2));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove the last element only if the delete count exceeds array length', () => {
+      const spliced = marr.splice(marr.length - 1, 2);
+
+      expect(spliced.length).toEqual(1);
+      expect(spliced.toArray()).toEqual(arr.splice(arr.length - 1, 2));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should insert an element at index without removing existing ones', () => {
+      const spliced = marr.splice(1, 0, 8);
+
+      expect(spliced.length).toEqual(0);
+      expect(marr.length).toEqual(6);
+      expect(marr[1]).toEqual(8);
+      expect(spliced.toArray()).toEqual(arr.splice(1, 0, 8));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should insert multiple elements without removing existing ones', () => {
+      const spliced = marr.splice(1, 0, 4, 12, 60);
+
+      expect(spliced.length).toEqual(0);
+      expect(marr.length).toEqual(8);
+      expect([marr[1], marr[2], marr[3]]).toEqual([4, 12, 60]);
+      expect(spliced.toArray()).toEqual(arr.splice(1, 0, 4, 12, 60));
+      expect(marr.toArray()).toEqual(arr);
+    });
+
+    it('should remove elements and insert new ones at a specified index', () => {
+      const spliced = marr.splice(1, 2, 10, 50, 100);
+
+      expect(spliced.length).toEqual(2);
+      expect(marr.length).toEqual(6);
+      expect([marr[1], marr[2], marr[3]]).toEqual([10, 50, 100]);
+      expect(spliced.toArray()).toEqual(arr.splice(1, 2, 10, 50, 100));
+      expect(marr.toArray()).toEqual(arr);
+    });
+  });
+
   describe('MArray iteration test suite', () => {
     it('should be iterable by a for...of loop', () => {
       const mArray = new MArray(1, 2, 3, 4, 5);

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -96,11 +96,22 @@ export class MArray<T> {
    * @param deleteCount item count to delete
    * @param items items to insert
    */
-  splice(at: number, deleteCount: number, ...items: T[]) {
-    tu.remove(this.$data, at, deleteCount);
+  splice(at: number, deleteCount?: number, ...items: T[]) {
+    let deletedElements = new MArray<T>();
+    at = at < 0 ? this.length + at : at;
+
+    if (at < this.length) {
+      deleteCount = deleteCount ?? this.length - at;
+      if (deleteCount > 0) {
+        deletedElements = this.slice(at, at + deleteCount);
+        tu.remove(this.$data, at, deleteCount);
+      }
+    }
     if (items.length > 0) {
       tu.insert(this.$data, at, items);
     }
+
+    return deletedElements;
   }
 
   /**

--- a/src/tree-utils.ts
+++ b/src/tree-utils.ts
@@ -148,8 +148,8 @@ export function remove<T>(root: INode<T>, start: number, count: number) {
             // Special case, if we remove the entire tree, empty the root.
             while (node.size) {
               node.pop();
-              return;
             }
+            return;
           } else {
             // Otherwise remove the entire node
             count -= node.getField(Size);

--- a/tests/structure.test.ts
+++ b/tests/structure.test.ts
@@ -150,6 +150,13 @@ describe('Internal tree structure', () => {
     expect(atIndex(tree, 2).data).toBe(14);
   });
 
+  it('Correctly removes all nodes', () => {
+    const tree = fromArray(data);
+    remove(tree, 0, data.length);
+    expect(isBalanced(tree)).toBeTruthy();
+    expect(tree.getField(Size)).toEqual(0);
+  });
+
   it('Correctly inserts a single node at the start', () => {
     const tree = fromArray(data);
     insert(tree, 0, [-1]);


### PR DESCRIPTION
The MArray.splice() method is modified to match the Array.splice implementation (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) and tests are added to confirm the behavior.
An edge-case in the tree-utils `remove` method is also fixed.

Task: [EDI-1619](https://h4jira.atlassian.net/browse/EDI-1619)