### PR TITLE
EDI-1607 Implement MArray equivalent of trackArray

### DIFF
--- a/src/marray-utils.ts
+++ b/src/marray-utils.ts
@@ -1,0 +1,22 @@
+export class EventHandler<T = undefined, U = void> {
+  private handlers: Array<(t: T) => U> = [];
+
+  addListener(f: (t: T) => U) {
+    this.handlers.push(f);
+  }
+
+  run(t: T) {
+    this.handlers.forEach(handler => handler(t));
+  }
+
+  removeListener(f: (t: T) => U) {
+    this.handlers.splice(this.handlers.indexOf(f), 1);
+  }
+}
+
+export function toInteger(s: any): number | null {
+  if (s === '' || typeof s === 'symbol') return null;
+  let n = Number(s);
+  if (Number.isInteger(n)) return n;
+  return null;
+}

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -217,8 +217,9 @@ export class MArray<T> {
   }
 
   update(index: number, val: T) {
-    const oldVal = tu.atIndex(this.$data, index).data;
-    tu.atIndex(this.$data, index).data = val;
+    const dataHolder = tu.atIndex(this.$data, index);
+    const oldVal = dataHolder.data;
+    dataHolder.data = val;
     if (val !== oldVal) {
       this.onRemoveHandler.run(oldVal);
       this.onCreateHandler.run(val);

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -1,16 +1,12 @@
 import * as ts from './tree-structure';
 import * as tu from './tree-utils';
-
-function toInteger(s: any): number | null {
-  if (s === '' || typeof s === 'symbol') return null;
-  let n = Number(s);
-  if (Number.isInteger(n)) return n;
-  return null;
-}
+import { EventHandler, toInteger } from './marray-utils';
 
 export class MArray<T> {
   [n: number]: T;
   private $data: ts.INode<T>;
+  private onCreateHandler: EventHandler<T>;
+  private onRemoveHandler: EventHandler<T>;
 
   static from<T>(items: Iterable<T>) {
     const arr = new MArray<T>();
@@ -20,6 +16,8 @@ export class MArray<T> {
 
   constructor(...items: T[]) {
     this.$data = tu.fromArray(items);
+    this.onCreateHandler = new EventHandler();
+    this.onRemoveHandler = new EventHandler();
 
     return new Proxy(this, {
       get: (target, prop, receiver) => {
@@ -40,25 +38,59 @@ export class MArray<T> {
     });
   }
 
+  track(onCreated: (t: T) => void, onRemoved: (t: T) => void) {
+    this.onCreateHandler.addListener(onCreated);
+    this.onRemoveHandler.addListener(onRemoved);
+    return () => {
+      this.onCreateHandler.removeListener(onCreated);
+      this.onRemoveHandler.removeListener(onRemoved);
+    };
+  }
+
+  /**
+   * Insert items at given position
+   * @param at the position
+   * @param item the content
+   */
+  private insert(at: number, items: T[]) {
+    tu.insert(this.$data, at, items);
+    items.forEach(i => this.onCreateHandler.run(i));
+  }
+
+  /**
+   * Removes the specified number of items from a given index
+   * @param start the starting index
+   * @param count number of items to be removed
+   */
+  private remove(start: number, count: number) {
+    let removed;
+    if (count > 0) removed = this.slice(start, start + count);
+    tu.remove(this.$data, start, count);
+    for (let i of removed) {
+      this.onRemoveHandler.run(i);
+    }
+  }
+
   push(...items: T[]) {
-    tu.insert(this.$data, this.length, items);
+    this.insert(this.length, items);
   }
 
   pop() {
     let lastIndex = this.$data.getField(tu.Size) - 1;
+    if (lastIndex < 0) return undefined;
     let item = tu.atIndex(this.$data, lastIndex);
-    tu.remove(this.$data, lastIndex, 1);
+    this.remove(lastIndex, 1);
     return item.data;
   }
 
   shift() {
     let item = tu.atIndex(this.$data, 0);
-    tu.remove(this.$data, 0, 1);
+    this.remove(0, 1);
     return item.data;
   }
 
   unshift(t: T) {
-    tu.insert(this.$data, 0, [t]);
+    this.insert(0, [t]);
   }
 
   /**
@@ -104,23 +136,14 @@ export class MArray<T> {
       deleteCount = deleteCount ?? this.length - at;
       if (deleteCount > 0) {
         deletedElements = this.slice(at, at + deleteCount);
-        tu.remove(this.$data, at, deleteCount);
+        this.remove(at, deleteCount);
       }
     }
     if (items.length > 0) {
-      tu.insert(this.$data, at, items);
+      this.insert(at, items);
     }
 
     return deletedElements;
-  }
-
-  /**
-   * Insert item at given position
-   * @param at the position
-   * @param item the content
-   */
-  insert(at: number, item: T) {
-    tu.insert(this.$data, at, [item]);
   }
 
   /**
@@ -144,7 +167,7 @@ export class MArray<T> {
   }
 
   /**
-   * Like Array.every; returns true if all elements satifsy the predicate
+   * Like Array.every; returns true if all elements satisfy the predicate
    * @param predicate
    * @param thisArg?
    * @returns boolean
@@ -194,7 +217,12 @@ export class MArray<T> {
   }
 
   update(index: number, val: T) {
+    const oldVal = tu.atIndex(this.$data, index).data;
     tu.atIndex(this.$data, index).data = val;
+    if (val !== oldVal) {
+      this.onRemoveHandler.run(oldVal);
+      this.onCreateHandler.run(val);
+    }
   }
 
   foldTo<Val>(index: number, monoid: ts.MonoidObj<Val, T>) {


### PR DESCRIPTION
- Implemented event handler class and moved it to a new `marray-utils.ts` file;
- Implemented a `MArray.track` method that adds onCreate and onRemove listeners to the MArray class, and returns functions to remove the listeners;
- Implemented private `remove` and `insert` methods that wrap the direct tree modification methods and run the onCreate and onRemove handlers accordingly;
- Replaced all `tu.insert` and `tu.remove` usages with the newly created ones in all MArray methods that modify the string, as well as in the `update` method;
- Added tests to confirm behavior;
- Bonus: Fixed the `MArray.pop` implementation to handle empty array case (should return undefined by spec).

Task: [EDI-1607](https://h4jira.atlassian.net/browse/EDI-1607)