### PR TITLE
Make slice a mutation free operation.

### DIFF
--- a/src/marray.ts
+++ b/src/marray.ts
@@ -100,10 +100,10 @@ export class MArray<T> {
    * @param end The end of the specified portion of the array, exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number) {
-    const extractedElements = new MArray<T>();
+    const extractedElements: Array<T> = [];
 
     if (start > this.length) {
-      return extractedElements;
+      return MArray.from(extractedElements);
     } else if (start < 0) {
       start = this.length + start;
     }
@@ -120,7 +120,7 @@ export class MArray<T> {
       }
     }
 
-    return extractedElements;
+    return MArray.from(extractedElements);
   }
 
   /**


### PR DESCRIPTION
Due to the way MobX works creating a new MArray by making an empty
array then mutating it to get to a result will cause a failure in
its cycle detection heuristics.

See a simple example here: https://github.com/mobxjs/mobx/issues/1684

To make sure this issue isn't a problem, we make all methods that
don't mutate the source MArray use the MArray constructor. The constructor
is safe as it doesn't subsequently mutate the newly created observable
values, nor it tries to read them.

This PR applies the fix to the slice method; previous PRs applied it
to map, filter and similar methods. A realworld test was added to
simulate this scenario which should ensure we dont have a regression