### PR TITLE
Property test for MArray.slice()

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.11",
     "asciitree": "^1.0.2",
+    "fast-check": "^2.13.0",
     "jest": "^26.6.3",
     "parcel-bundler": "^1.12.0",
     "prettier": "^1.16.4",

--- a/src/marray.test.ts
+++ b/src/marray.test.ts
@@ -1,5 +1,5 @@
 import * as fc from 'fast-check';
-import { MArray } from '../src';
+import { MArray } from '.';
 
 describe('mArray', () => {
   it('slice should work with randomly generated splice operations', () => {

--- a/src/marray.ts
+++ b/src/marray.ts
@@ -131,7 +131,8 @@ export class MArray<T> {
    */
   splice(at: number, deleteCount?: number, ...items: T[]) {
     let deletedElements = new MArray<T>();
-    at = at < 0 ? this.length + at : at;
+    // Specs: https://tc39.es/ecma262/#sec-array.prototype.splice
+    at = at < 0 ? Math.max(this.length + at, 0) : Math.min(this.length, at);
 
     if (at + deleteCount > this.length) {
       deleteCount = this.length - at;

--- a/tests/marray.test.ts
+++ b/tests/marray.test.ts
@@ -27,9 +27,6 @@ describe('mArray', () => {
           }
         },
       ),
-      {
-        numRuns: 50,
-      },
     );
   });
 });

--- a/tests/marray.test.ts
+++ b/tests/marray.test.ts
@@ -2,7 +2,7 @@ import * as fc from 'fast-check';
 import { MArray } from '../src';
 
 describe('mArray', () => {
-  it.only('slice should work with randomly generated splice operations', () => {
+  it('slice should work with randomly generated splice operations', () => {
     fc.assert(
       fc.property(
         fc.array(fc.integer(), { maxLength: 1000 }),

--- a/tests/marray.test.ts
+++ b/tests/marray.test.ts
@@ -10,8 +10,8 @@ describe('mArray', () => {
         fc.array(fc.integer(), { maxLength: ARR_MAX_LENGTH }),
         fc.array(
           fc.record({
-            at: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob a case where the index is out of bounds is between 0-50%
-            deleteCount: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob a case where the count is out of bounds is between 0-50%
+            at: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob distrib a case where the index is out of bounds is between 0-50%
+            deleteCount: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob distrib a case where the count is out of bounds is between 0-50%
             add: fc.array(fc.integer(), { maxLength: ARR_MAX_LENGTH }),
           }),
         ),

--- a/tests/marray.test.ts
+++ b/tests/marray.test.ts
@@ -3,14 +3,16 @@ import { MArray } from '../src';
 
 describe('mArray', () => {
   it('slice should work with randomly generated splice operations', () => {
+    const ARR_MAX_LENGTH = 1000;
+
     fc.assert(
       fc.property(
-        fc.array(fc.integer(), { maxLength: 1000 }),
+        fc.array(fc.integer(), { maxLength: ARR_MAX_LENGTH }),
         fc.array(
           fc.record({
-            at: fc.integer(-2000, 2000), // So the prob a case where the index is out of bounds is between 0-50%
-            deleteCount: fc.integer(-2000, 2000), // So the prob a case where the count is out of bounds is between 0-50%
-            add: fc.array(fc.integer(), { maxLength: 1000 }),
+            at: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob a case where the index is out of bounds is between 0-50%
+            deleteCount: fc.integer(-ARR_MAX_LENGTH * 2, ARR_MAX_LENGTH * 2), // So the prob a case where the count is out of bounds is between 0-50%
+            add: fc.array(fc.integer(), { maxLength: ARR_MAX_LENGTH }),
           }),
         ),
         (data, splices) => {

--- a/tests/marray.test.ts
+++ b/tests/marray.test.ts
@@ -1,0 +1,33 @@
+import * as fc from 'fast-check';
+import { MArray } from '../src';
+
+describe('mArray', () => {
+  it.only('slice should work with randomly generated splice operations', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer(), { maxLength: 1000 }),
+        fc.array(
+          fc.record({
+            at: fc.integer(-2000, 2000), // So the prob a case where the index is out of bounds is between 0-50%
+            deleteCount: fc.integer(-2000, 2000), // So the prob a case where the count is out of bounds is between 0-50%
+            add: fc.array(fc.integer(), { maxLength: 1000 }),
+          }),
+        ),
+        (data, splices) => {
+          const mArray = MArray.from(data);
+
+          for (const record of splices) {
+            const delsArray = data.splice(record.at, record.deleteCount, ...record.add);
+            const delsMArray = mArray.splice(record.at, record.deleteCount, ...record.add);
+
+            expect(delsMArray.toArray()).toEqual(delsArray);
+            expect(mArray.toArray()).toEqual(data);
+          }
+        },
+      ),
+      {
+        numRuns: 50,
+      },
+    );
+  });
+});


### PR DESCRIPTION
Implements a property test for MArray.slice()

- Added fast-check library
- Added `/tests/marray.test.ts`
- Fixed `slice()` in `MArray` for cases where the `at < 0` & `at > arr.length`